### PR TITLE
Update/add checks for `availability_domain` & `route_table_id`

### DIFF
--- a/visualiser/generators/okitGenerator.py
+++ b/visualiser/generators/okitGenerator.py
@@ -677,7 +677,7 @@ class OCIGenerator(object):
         # ---- Display Name
         self.addJinja2Variable("display_name", local_peering_gateway["display_name"], standardisedName)
         # ---- Route Table
-        if len(local_peering_gateway['route_table_id']) > 0:
+        if local_peering_gateway.get('route_table_id') and len(local_peering_gateway['route_table_id']) > 0:
             self.jinja2_variables["route_table_id"] = self.formatJinja2IdReference(self.standardiseResourceName(self.id_name_map[local_peering_gateway['route_table_id']]))
         else:
             self.jinja2_variables.pop("route_table_id", None)
@@ -1091,7 +1091,7 @@ class OCIGenerator(object):
             self.jinja2_variables["dhcp_options_id"] = self.formatJinja2DhcpReference(self.standardiseResourceName(self.id_name_map[subnet['vcn_id']]))
         # --- Optional
         # ---- Availability Domain
-        if subnet.get("availability_domain", None) is not None and int(subnet["availability_domain"]) > 0:
+        if subnet.get("availability_domain", None) is not None and len(subnet["availability_domain"]) > 0:
             self.addJinja2Variable("availability_domain", subnet["availability_domain"], standardisedName)
         else:
             self.jinja2_variables.pop("availability_domain", None)


### PR DESCRIPTION
 - availability domain
    - Modified from int conversion & check to length of string & check
- route table id
    - Added None check to `route_table_id` dictionary conditional


No previous issue
    - These issues occurred during tf generation on the backend via the frontend 

Ensure that any documentation is updated with the changes that are required by your fix.
- I don't think required in this scenario

Ensure that any samples are updated if the base image has been changed.
- No Change

Explain exactly what your changes are meant to do and provide simple steps on how to validate your changes.
- Check for no `route_table_id` field from OCI
    - Reproduce with no `route_table_id`
- Convert check for `availability_domain` from an integer conversion to the length of the string.
    - Reproduce with `{ "availability_domain" : "fee:fi-fo-fum-1"}`








Signed-off-by: Your Name daniel.aaron.feser@gmail.com
