### PR TITLE
Fix fast discovery for FileSystem Export and ExportSet resources

### DIFF
--- a/visualiser/discovery/models/README.md
+++ b/visualiser/discovery/models/README.md
@@ -16,5 +16,5 @@ resources
 * **`ExtendedNetworkSecurityGroupVnic`** - adds the associated
   `network_security_group_id` to `oci.core.models.NetworkSecurityGroupVnic`
 
-* **`ExtendedBucketSummary`** - adds the buckets `compartment_id` to
-  `oci.object_storage.models.BucketSummary`
+* **`ExtendedExportSummary`** - adds the export `compartment_id` to
+  `oci.object_storage.models.ExportSummary`

--- a/visualiser/discovery/models/__init__.py
+++ b/visualiser/discovery/models/__init__.py
@@ -3,11 +3,12 @@
 from .application_migration import ExtendedSourceApplicationSummary
 from .autoscaling import ExtendedAutoScalingPolicySummary
 from .core import ExtendedSecurityRule, ExtendedNetworkSecurityGroupVnic
-from .object_storage import ExtendedBucketSummary, ExtendedPreauthenticatedRequestSummary
+from .file_storage import ExtendedExportSummary
+from .object_storage import ExtendedPreauthenticatedRequestSummary
 
 __all__ = [
   "ExtendedAutoScalingPolicySummary",
-  "ExtendedBucketSummary",
+  "ExtendedExportSummary",
   "ExtendedNetworkSecurityGroupVnic",
   "ExtendedPreauthenticatedRequestSummary",
   "ExtendedSecurityRule",

--- a/visualiser/discovery/models/file_storage.py
+++ b/visualiser/discovery/models/file_storage.py
@@ -1,0 +1,21 @@
+# Copyright © 2021, Oracle and/or its affiliates. All rights reserved.
+
+from oci.file_storage.models import ExportSummary
+
+# extend ExportSummary to add compartment id
+class ExtendedExportSummary(ExportSummary):
+
+    _compartment_id = None
+
+    @property
+    def compartment_id(self):
+        return self._compartment_id
+
+    def __init__(self, compartment_id, export: ExportSummary):
+        attrs = [item for item in dir(ExportSummary) if not item.startswith('_') and item[0].islower()]
+        init_args = {}
+        for attr in attrs:
+            init_args[attr] = getattr(export, attr)
+        super().__init__(**init_args)
+        self._compartment_id = compartment_id
+        self.swagger_types.update({"compartment_id": "str"})

--- a/visualiser/discovery/models/object_storage.py
+++ b/visualiser/discovery/models/object_storage.py
@@ -1,24 +1,6 @@
 # Copyright © 2021, Oracle and/or its affiliates. All rights reserved.
 
-from oci.object_storage.models import BucketSummary, PreauthenticatedRequestSummary
-
-# extend BucketSummary to add compartment id
-class ExtendedBucketSummary(BucketSummary):
-
-    _compartment_id = None
-
-    @property
-    def compartment_id(self):
-        return self._compartment_id
-
-    def __init__(self, compartment_id, bucket: BucketSummary):
-        attrs = [item for item in dir(BucketSummary) if not item.startswith('_') and item[0].islower()]
-        init_args = {}
-        for attr in attrs:
-            init_args[attr] = getattr(bucket, attr)
-        super().__init__(**init_args)
-        self._compartment_id = compartment_id
-        self.swagger_types.update({"compartment_id": "str"})
+from oci.object_storage.models import PreauthenticatedRequestSummary
 
 # extend PreauthenticatedRequest to add compartment id  and bucket id
 

--- a/visualiser/discovery/oci_discovery_client.py
+++ b/visualiser/discovery/oci_discovery_client.py
@@ -11,7 +11,7 @@ import sys
 from common.okitLogging import getLogger
 from concurrent.futures import ThreadPoolExecutor
 
-from .models import ExtendedAutoScalingPolicySummary, ExtendedBucketSummary, ExtendedNetworkSecurityGroupVnic, ExtendedPreauthenticatedRequestSummary, ExtendedSecurityRule, ExtendedSourceApplicationSummary
+from .models import ExtendedAutoScalingPolicySummary, ExtendedNetworkSecurityGroupVnic, ExtendedPreauthenticatedRequestSummary, ExtendedSecurityRule, ExtendedSourceApplicationSummary, ExtendedExportSummary
 
 DEFAULT_MAX_WORKERS = 32
 DEFAULT_TIMEOUT = 120
@@ -516,9 +516,9 @@ class OciResourceDiscoveryClient(object):
                         future = executor.submit(self.list_resources, klass, method_name, region, compartment_id=compartment_id, db_system_id=db_system_id)
                         futures_list.update({(region, resource_type, compartment_id, db_system_id):future})
                     elif method_name == "list_exports":
-                        export_set_id = item[2]
-                        future = executor.submit(self.list_resources, klass, method_name, region, export_set_id=export_set_id)
-                        futures_list.update({(region, resource_type, compartment_id, export_set_id):future})
+                        file_system_id = item[2]
+                        future = executor.submit(self.list_resources, klass, method_name, region, file_system_id=file_system_id)
+                        futures_list.update({(region, resource_type, compartment_id, file_system_id):future})
                     elif method_name == "list_functions":
                         application_id = item[2]
                         future = executor.submit(self.list_resources, klass, method_name, region, application_id=application_id)
@@ -633,9 +633,13 @@ class OciResourceDiscoveryClient(object):
                         # map Source Applications into extended verison a unique id
                         new_result = [ExtendedSourceApplicationSummary(f"{future[3]}/{application.type}/{application.name}", application) for application in result]
                         result = new_result
-                    if resource_type == "AutoScalingPolicy":
+                    elif resource_type == "AutoScalingPolicy":
                         # map Auto Scaling Policy into extended verison parent id
                         new_result =  [ExtendedAutoScalingPolicySummary(future[3],policy) for policy in result]
+                        result = new_result
+                    elif resource_type == "Export":
+                        # map Export into extended verison with compartment id
+                        new_result =  [ExtendedExportSummary(future[2],export) for export in result]
                         result = new_result
                     elif resource_type == "NetworkSecurityGroupSecurityRule":
                         # map Security Rules into extended verison with parent id
@@ -779,7 +783,8 @@ class OciResourceDiscoveryClient(object):
                 elif resource.resource_type == "Drg" and (self.include_resource_types == None or "DrgAttachment" in self.include_resource_types):
                     # get Drg Attachments for Drgs
                     regional_resource_requests.add(("DrgAttachment", resource.compartment_id, None))
-                elif resource.resource_type == "ExportSet" and (self.include_resource_types == None or "Export" in self.include_resource_types):
+                elif resource.resource_type == "FileSystem" and (self.include_resource_types == None or "Export" in self.include_resource_types):
+                    # get Exports for FileSystem
                     regional_resource_requests.add(("Export", resource.compartment_id, resource.identifier))
                 elif resource.resource_type == "Group" and (self.include_resource_types == None or "UserGroupMembership" in self.include_resource_types):
                     # get Users for Groups
@@ -820,6 +825,9 @@ class OciResourceDiscoveryClient(object):
                     #     regional_resource_requests.add(("RuleSet", resource.compartment_id, resource.identifier))
                     # if self.include_resource_types == None or "SSLCipherSuite" in self.include_resource_types:
                     #     regional_resource_requests.add(("SSLCipherSuite", resource.compartment_id, resource.identifier))
+                elif resource.resource_type == "MountTarget" and (self.include_resource_types == None or "ExportSet" in self.include_resource_types):
+                    # get ExportSets in the same compartment and AD as the MountTarget
+                    regional_resource_requests.add(("ExportSet", resource.compartment_id, resource.availability_domain))
                 elif resource.resource_type == "NetworkSecurityGroup" and (self.include_resource_types == None or "NetworkSecurityGroupSecurityRule" in self.include_resource_types):
                     # get security rules for network secuity group 
                     regional_resource_requests.add(("NetworkSecurityGroupSecurityRule", resource.compartment_id, resource.identifier))
@@ -849,7 +857,6 @@ class OciResourceDiscoveryClient(object):
                 "DataSafeOnPremConnector", # Data Safe
                 "Resolver", "SteeringPolicy", "TSIGKey", "View", "Zone", # DNS
                 "EmailSuppression", # Email
-                "ExportSet", # File Service
                 "LogGroup", "LogSavedSearch", # Loging
                 "ManagementDashboard", # TODO test
                 "MySqlDbSystem", "MySQLChannel", "MySQLBackup", # MySQL


### PR DESCRIPTION
- Change discovery logic to fetch `Exports` per parent `FileSystem`
- Change discovery logic to fetch `ExportSets` in the same compartment and AD as the parent `MountTarget`
- Remove `ExportSet` from brute force discovery (wasn't working anyway)
- Added `ExtendedExportSummary` to extend the Export resource with `compartment_id` from the parent file systems compartment