### PR TITLE
 SHELL is not supported for OCI image format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ LABEL "provider"="Oracle" \
       "version"="0.26.0" \
       "description"="OKIT Web Server Container." \
       "copyright"="Copyright (c) 2020, 2021, Oracle and/or its affiliates."
-SHELL ["/bin/bash", "-c"]
 ENV PYTHONIOENCODING=utf8 \
     PYTHONPATH=":/okit/visualiser:/okit/okitweb:/okit" \
     FLASK_APP=okitweb \


### PR DESCRIPTION
To eliminate WARNING
```
WARN[----] SHELL is not supported for OCI image format, [/bin/bash -c] will be ignored. Must use `docker` format 
```