### PR TITLE
Build from Source - Version Dockerfile/oraclelinux

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -496,12 +496,16 @@ The docker image is the recommended runtime server OKIT provides a simple Docker
 - Create local directory __~/okit/user/templates__ for storage of custom templates.
 - [Copy Config & Key Files](#copy-config--key-files)
 
-##### Docker Compose Build
+##### Docker Compose Build From oraclelinux:7-slim
 ```bash
 cd oci-designer-toolkit/containers/docker
 docker-compose up --detach
 ```
-
+##### Docker Compose Build From oraclelinux:8-slim
+```bash
+cd oci-designer-toolkit/containers/docker/8-slim
+docker-compose up --detach
+```
 ##### Docker Compose Update
 ```bash
 cd oci-designer-toolkit/containers/docker


### PR DESCRIPTION
I installed wsl oracle linux 8.5 on my machine, but the dockerfile of the oraclelixux:7-slim version has an error. In this case I used the oraclelixux:8-slim version that was in another path.