### PR TITLE
fix pcaRegions response format

### DIFF
--- a/okitweb/okitPca.py
+++ b/okitweb/okitPca.py
@@ -119,8 +119,9 @@ def pcaRegions():
     if request.method == 'GET':
         config_profile = request.args.get('profile', default='DEFAULT')
         logger.info('Using Profile : {0!s:s}'.format(config_profile))
-        query = PCARegionQuery(config={}, profile=config_profile)
-        response = query.executeQuery()
+        regions_query = PCARegionQuery(config={}, profile=config_profile)
+        regions = regions_query.executeQuery()
+        response = jsonToFormattedString(regions)
         logJson(response)
         return response
     else:


### PR DESCRIPTION
Issue 587
fixed response formatting for pcaRegionsQuery to return JSON formatted output.

Validation Steps:
- OCI CLI Environment with DEFAULT and pca1 profile (both same content as of now)
- Opening okit web app at https://hostname:port/okit/pca
- Region Dropdown is populating with correct value (top right corner) when switching from one profile to another.

