### PR TITLE
fix: replace hardcoded SECRET_KEY with secure random generation and r…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN yum install -y \
  && alternatives --set python3 /usr/bin/python3.8 \
 # Configure ssh
  && echo 'Host *' > /etc/ssh/ssh_config \
- && echo '  StrictHostKeyChecking no' >> /etc/ssh/ssh_config \
- && echo '  UserKnownHostsFile=/dev/null' >> /etc/ssh/ssh_config \
+ && echo '  StrictHostKeyChecking accept-new' >> /etc/ssh/ssh_config \
+ && echo '  UserKnownHostsFile ~/.ssh/known_hosts' >> /etc/ssh/ssh_config \
 # Upgrade pip
  && python3 -m pip install --upgrade pip \
 # Create Workspace

--- a/okitclassic/okitserver/config.py
+++ b/okitclassic/okitserver/config.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2020, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+import os
+import secrets
 
-SECRET_KEY='8980ffsd675747jjjh'
+# Use environment variable; fallback to a cryptographically secure random string
+SECRET_KEY = os.getenv('SECRET_KEY', secrets.token_hex(32))


### PR DESCRIPTION
Remediate hardcoded Flask SECRET_KEY (CWE-798) and disabled SSH StrictHostKeyChecking (CWE-295). Replace the static secret with a cryptographically secure random fallback via secrets.token_hex() and restore SSH host verification by switching to accept-new policy in the Dockerfile.